### PR TITLE
Support own goals and filter unknown scorers

### DIFF
--- a/src/components/Admin/Matches/MatchResultForm.tsx
+++ b/src/components/Admin/Matches/MatchResultForm.tsx
@@ -5,7 +5,11 @@ import { playersApi } from "../../../utils/adminSupabase";
 
 interface MatchResultFormProps {
   match: Match;
-  onSubmit: (scoreHome: number, scoreAway: number, goalScorers?: { goals: Array<{ team_id: string; player_id: string; time: number }> }) => Promise<void>;
+  onSubmit: (
+    scoreHome: number,
+    scoreAway: number,
+    goalScorers?: { goals: Array<{ team_id: string; player_id?: string; time: number; own_goal?: boolean }> }
+  ) => Promise<void>;
   onCancel: () => void;
 }
 
@@ -14,6 +18,7 @@ interface GoalEntry {
   team_id: string;
   player_id: string;
   time: number;
+  own?: boolean;
 }
 
 export const MatchResultForm = ({
@@ -41,6 +46,7 @@ export const MatchResultForm = ({
         team_id: goal.team_id || "",
         player_id: goal.player_id || "",
         time: goal.time || 0,
+        own: goal.own_goal || false,
       }));
       setGoals(existingGoals);
     }
@@ -56,42 +62,39 @@ export const MatchResultForm = ({
   };
 
   const handleAddGoal = () => {
-    setGoals([
-      ...goals,
+    setGoals((currentGoals) => [
+      ...currentGoals,
       {
         id: Math.random().toString(36).substr(2, 9),
         team_id: match.home_team_id || "",
         player_id: "",
         time: 0,
+        own: false,
       },
     ]);
   };
 
   const handleRemoveGoal = (goalId: string) => {
-    setGoals(goals.filter((g) => g.id !== goalId));
+    setGoals((currentGoals) => currentGoals.filter((g) => g.id !== goalId));
   };
 
   const handleGoalChange = (
     goalId: string,
-    field: "team_id" | "player_id" | "time",
-    value: string | number
+    field: "team_id" | "player_id" | "time" | "own",
+    value: string | number | boolean
   ) => {
-    setGoals(
-      goals.map((g) => (g.id === goalId ? { ...g, [field]: value } : g))
+    setGoals((currentGoals) =>
+      currentGoals.map((g) => (g.id === goalId ? { ...g, [field]: value } : g))
     );
-  };
-
-  const getTeamPlayers = (teamId: string) => {
-    return players.filter((p) => p.team_id === teamId);
   };
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
 
     // Validate that all goals have required fields
-    const invalidGoals = goals.filter(g => !g.team_id || !g.player_id);
+    const invalidGoals = goals.filter((g) => !g.team_id || (!g.own && !g.player_id));
     if (invalidGoals.length > 0) {
-      showToast("All goals must have team and player selected", "error");
+      showToast("All goals must have a team selected", "error");
       return;
     }
 
@@ -111,13 +114,14 @@ export const MatchResultForm = ({
 
     setLoading(true);
     try {
-      const goalScorersData = {
-        goals: goals.map((g) => ({
-          team_id: g.team_id,
-          player_id: g.player_id,
-          time: Number(g.time),
-        })),
-      };
+        const goalScorersData = {
+          goals: goals.map((g) => ({
+            team_id: g.team_id,
+              player_id: g.own ? undefined : g.player_id,
+            time: Number(g.time),
+            own_goal: Boolean(g.own),
+          })),
+        };
 
       console.log("Submitting match result:", {
         scoreHome,
@@ -235,7 +239,31 @@ export const MatchResultForm = ({
             {goals.map((goal, idx) => (
               <div key={goal.id} className="bg-white border-2 border-blue-300 p-3 space-y-2">
                 <div className="flex justify-between items-start">
-                  <div className="font-black text-xs uppercase">Goal {idx + 1}</div>
+                  <div>
+                    <div className="font-black text-xs uppercase">Goal {idx + 1}</div>
+                    <label className="inline-flex items-center text-xs gap-2 mt-1">
+                      <input
+                        type="checkbox"
+                        checked={!!goal.own}
+                        onChange={(e) => {
+                          setGoals((currentGoals) =>
+                            currentGoals.map((currentGoal) =>
+                              currentGoal.id === goal.id
+                                ? {
+                                    ...currentGoal,
+                                    own: e.target.checked,
+                                    player_id: e.target.checked ? "" : currentGoal.player_id,
+                                  }
+                                : currentGoal
+                            )
+                          );
+                        }}
+                        disabled={loading}
+                        className="w-4 h-4"
+                      />
+                      <span className="font-bold">Own goal (samobój)</span>
+                    </label>
+                  </div>
                   <button
                     type="button"
                     onClick={() => handleRemoveGoal(goal.id)}
@@ -270,27 +298,34 @@ export const MatchResultForm = ({
                     </select>
                   </div>
 
-                  {/* Player */}
-                  <div>
-                    <label className="block text-xs font-black uppercase mb-1">
-                      Player *
-                    </label>
-                    <select
-                      value={goal.player_id}
-                      onChange={(e) =>
-                        handleGoalChange(goal.id, "player_id", e.target.value)
-                      }
-                      className="w-full px-2 py-1 border-2 border-black text-xs bg-white"
-                      disabled={loading || !goal.team_id}
-                    >
-                      <option value="">-- Select --</option>
-                      {getTeamPlayers(goal.team_id).map((player) => (
-                        <option key={player.id} value={player.id}>
-                          {player.first_name} {player.last_name}
-                        </option>
-                      ))}
-                    </select>
-                  </div>
+                  {!goal.own ? (
+                    <div>
+                      <label className="block text-xs font-black uppercase mb-1">
+                        Player *
+                      </label>
+                      <select
+                        value={goal.player_id}
+                        onChange={(e) =>
+                          handleGoalChange(goal.id, "player_id", e.target.value)
+                        }
+                        className="w-full px-2 py-1 border-2 border-black text-xs bg-white"
+                        disabled={loading || !goal.team_id}
+                      >
+                        <option value="">-- Select --</option>
+                        {players
+                          .filter((p) => p.team_id === goal.team_id)
+                          .map((player) => (
+                            <option key={player.id} value={player.id}>
+                              {player.first_name} {player.last_name}
+                            </option>
+                          ))}
+                      </select>
+                    </div>
+                  ) : (
+                    <div className="border-2 border-dashed border-red-400 bg-red-50 px-3 py-2 text-xs font-black uppercase tracking-widest text-red-700 flex items-center justify-center text-center">
+                      Own goal only
+                    </div>
+                  )}
 
                   {/* Time */}
                   <div>

--- a/src/components/Admin/Matches/MatchesView.tsx
+++ b/src/components/Admin/Matches/MatchesView.tsx
@@ -250,7 +250,11 @@ export const MatchesView = () => {
     }
   };
 
-  const handleUpdateScore = async (scoreHome: number, scoreAway: number, goalScorers?: { goals: Array<{ team_id: string; player_id: string; time: number }> }) => {
+  const handleUpdateScore = async (
+    scoreHome: number,
+    scoreAway: number,
+    goalScorers?: { goals: Array<{ team_id: string; player_id?: string; time: number; own_goal?: boolean }> }
+  ) => {
     if (!selectedMatch) return;
     try {
       await matchesApi.updateMatchScore(selectedMatch.id, scoreHome, scoreAway, goalScorers);

--- a/src/components/Admin/Statistics/TopScorersView.tsx
+++ b/src/components/Admin/Statistics/TopScorersView.tsx
@@ -28,15 +28,17 @@ export const TopScorersView = () => {
       // Fetch directly from top_scorers table (pre-calculated)
       const scorers = await topScorersApi.getAll();
 
-      const mapped = scorers.map((scorer) => ({
-        id: scorer.id,
-        playerId: scorer.player_id,
-        playerName: scorer.player_name,
-        teamId: scorer.team_id,
-        teamName: scorer.team_name,
-        goals: scorer.goals,
-        school: scorer.school,
-      }));
+      const mapped = scorers
+        .filter((scorer) => Boolean(scorer.player_id) && scorer.player_name !== "Unknown")
+        .map((scorer) => ({
+          id: scorer.id,
+          playerId: scorer.player_id,
+          playerName: scorer.player_name,
+          teamId: scorer.team_id,
+          teamName: scorer.team_name,
+          goals: scorer.goals,
+          school: scorer.school,
+        }));
 
       setTopScorers(mapped);
     } catch (error) {
@@ -106,7 +108,7 @@ export const TopScorersView = () => {
                   <td className="px-4 py-2 text-xs uppercase">
                     {scorer.school}
                   </td>
-                  <td className="px-4 py-2 text-center text-xs font-black text-lg">
+                  <td className="px-4 py-2 text-center text-lg font-black">
                     {scorer.goals}
                   </td>
                 </tr>

--- a/src/components/Views/ScheduleView.tsx
+++ b/src/components/Views/ScheduleView.tsx
@@ -6,7 +6,8 @@ import type { PublicPlayer } from "../../types/publicData";
 interface Goal {
   time: number;
   team_id: string;
-  player_id: string;
+  player_id?: string;
+  own_goal?: boolean;
 }
 
 const hasTwoPartName = (name: string | null | undefined) => {
@@ -414,16 +415,20 @@ const ScheduleView = () => {
                                   .filter((g: Goal) => g.team_id === match.home_team_id)
                                   .sort((a: Goal, b: Goal) => a.time - b.time)
                                   .map((goal: Goal, idx: number) => {
-                                    const player = allPlayers.get(goal.player_id);
+                                    const player = goal.player_id ? allPlayers.get(goal.player_id) : undefined;
+                                    const isOwn = goal.own_goal;
                                     return (
                                       <li
                                         key={idx}
                                         className="flex justify-between items-center gap-2"
                                       >
-                                        <span className="font-bold truncate">
-                                          {player
-                                            ? `${player.first_name} ${player.last_name}`
-                                            : "Nieznany"}
+                                        <span className="font-bold truncate flex items-center">
+                                          <span>{isOwn || !player ? "" : `${player.first_name} ${player.last_name}`}</span>
+                                          {isOwn && (
+                                            <span className="inline-flex items-center px-2 py-0.5 border border-red-600 text-[10px] font-black uppercase tracking-widest text-red-700 bg-red-50 flex-shrink-0">
+                                            Bramka samobójcza
+                                            </span>
+                                          )}
                                         </span>
                                         <span className="text-gray-600 font-bold flex-shrink-0">
                                           {goal.time}'
@@ -453,16 +458,20 @@ const ScheduleView = () => {
                                   .filter((g: Goal) => g.team_id === match.away_team_id)
                                   .sort((a: Goal, b: Goal) => a.time - b.time)
                                   .map((goal: Goal, idx: number) => {
-                                    const player = allPlayers.get(goal.player_id);
+                                    const player = goal.player_id ? allPlayers.get(goal.player_id) : undefined;
+                                    const isOwn = goal.own_goal;
                                     return (
                                       <li
                                         key={idx}
                                         className="flex justify-between items-center gap-2"
                                       >
-                                        <span className="font-bold truncate">
-                                          {player
-                                            ? `${player.first_name} ${player.last_name}`
-                                            : "Nieznany"}
+                                        <span className="font-bold truncate flex items-center">
+                                          <span>{isOwn || !player ? "" : `${player.first_name} ${player.last_name}`}</span>
+                                          {isOwn && (
+                                            <span className="inline-flex items-center px-2 py-0.5 border border-red-600 text-[10px] font-black uppercase tracking-widest text-red-700 bg-red-50 flex-shrink-0">
+                                              Bramka samobójcza
+                                            </span>
+                                          )}
                                         </span>
                                         <span className="text-gray-600 font-bold flex-shrink-0">
                                           {goal.time}'

--- a/src/types/admin.ts
+++ b/src/types/admin.ts
@@ -75,8 +75,9 @@ export interface Match {
   goal_scorers?: {
     goals: Array<{
       team_id: string;
-      player_id: string;
+      player_id?: string;
       time: number;
+      own_goal?: boolean;
     }>;
   } | null;
   created_at: string;

--- a/src/types/publicData.ts
+++ b/src/types/publicData.ts
@@ -23,7 +23,8 @@ export interface PublicMatch {
     goals?: Array<{
       time: number;
       team_id: string;
-      player_id: string;
+      player_id?: string;
+      own_goal?: boolean;
     }>;
   } | null;
   home_team?: { name: string } | null;

--- a/src/utils/adminSupabase.ts
+++ b/src/utils/adminSupabase.ts
@@ -421,7 +421,7 @@ export const matchesApi = {
     matchId: string,
     scoreHome: number,
     scoreAway: number,
-    goalScorers?: { goals: Array<{ team_id: string; player_id: string; time: number }> }
+    goalScorers?: { goals: Array<{ team_id: string; player_id?: string; time: number; own_goal?: boolean }> }
   ): Promise<Match> {
     // Get match details
     const { data: match, error: matchError } = await (supabase as any)

--- a/src/utils/publicData/fetchPublicData.ts
+++ b/src/utils/publicData/fetchPublicData.ts
@@ -274,6 +274,7 @@ export const fetchPublicData = async (): Promise<FetchPublicDataResult> => {
       warnings.push(`top_scorers: ${error.message}`);
     } else {
       snapshot.topScorers = ((data || []) as any[])
+        .filter((row) => Boolean(row.player_id) && row.player_name !== "Unknown")
         .map((row) => ({
           id: toString(row.id),
           player_id: toString(row.player_id),


### PR DESCRIPTION
Add support for own goals across the app and filter out unknown/top-scorer noise. Key changes:

- MatchResultForm: add an `own` flag per goal, checkbox UI to mark own goals, disable player selection for own goals, update validation, use functional state updates, and send goal objects with `own_goal` and optional `player_id`.
- MatchesView / admin API: update handler and matchesApi signature to accept goals with optional `player_id` and `own_goal`.
- Types: mark goal.player_id optional and add `own_goal` to admin and public match types.
- ScheduleView: handle optional player_id and display an "own goal" badge for own goals.
- TopScorersView & fetchPublicData: filter out entries with missing player_id or player_name === "Unknown" to avoid showing anonymous scorers.

Also includes minor UI/style tweaks and safer state updates.